### PR TITLE
Run SonarCloud only on pull requests to master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,12 +100,6 @@ steps:
       eq(variables['System.PullRequest.TargetBranch'], 'master')
     )
 
-
-
-
-
-
-
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish code coverage report'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,6 @@ steps:
     command: 'restore'
     projects: '**/*.csproj'
 
-
 - task: SonarCloudPrepare@1
   displayName: 'Prepare SonarCloud analysis'
   inputs:


### PR DESCRIPTION
Run SonarCloud less often to reduce build times for normal CI builds.